### PR TITLE
Session/params hash fix

### DIFF
--- a/lib/authlogic_connect/common/variables.rb
+++ b/lib/authlogic_connect/common/variables.rb
@@ -2,42 +2,32 @@ module AuthlogicConnect::Common::Variables
   include AuthlogicConnect::Common::State
 
   attr_reader :processing_authentication
-  
+
   def auth_class
     is_auth_session? ? self.class : session_class
   end
-  
+
   def auth_controller
     is_auth_session? ? controller : session_class.controller
   end
-  
+
   def auth_params
-    return nil unless auth_controller?
-    auth_controller.params.symbolize_keys!
-    auth_controller.params.keys.each do |key|
-      auth_controller.params[key.to_s] = auth_controller.params.delete(key) if key.to_s =~ /^OpenID/
-    end
-    auth_controller.params
+    convert_open_id_keys_from_hash(auth_controller.params) if auth_controller?
   end
-  
+
   def auth_session
-    return nil unless auth_controller?
-    auth_controller.session.symbolize_keys!
-    auth_controller.session.keys.each do |key|
-      auth_controller.session[key.to_s] = auth_controller.session.delete(key) if key.to_s =~ /^OpenID/
-    end
-    auth_controller.session
+    convert_open_id_keys_from_hash(auth_controller.session) if auth_controller?
   end
-  
+
   def auth_callback_url(options = {})
     auth_controller.url_for({:controller => auth_controller.controller_name, :action => auth_controller.action_name}.merge(options))
   end
-  
+
   # if we've said it's a "user" (registration), or a "session" (login)
   def auth_type
     from_session_or_params(:authentication_type)
   end
-  
+
   # auth_params and auth_session attributes are all String!
   def from_session_or_params(attribute)
     return nil unless auth_controller?
@@ -46,16 +36,16 @@ module AuthlogicConnect::Common::Variables
     result = auth_session[key] if (result.nil? || result.blank?)
     result
   end
-  
+
   def add_session_key(key, value)
-    
+
   end
-  
+
   def remove_session_key(key)
     keys = key.is_a?(Symbol) ? [key, key.to_s] : [key, key.to_sym]
     keys.each {|k| auth_session.delete(k)}
   end
-    
+
   # wraps the call to "save" (in yield).
   # reason being, we need to somehow not allow oauth/openid validations to run
   # when we don't have a block.  We can't know that using class methods, so we create
@@ -67,14 +57,14 @@ module AuthlogicConnect::Common::Variables
     @processing_authentication = false
     saved
   end
-  
+
   # returns boolean
   def authentication_protocol(with, phase)
     returning(send("#{phase.to_s}_#{with.to_s}?")) do |ready|
       send("#{phase.to_s}_#{with.to_s}") if ready
     end if send("using_#{with.to_s}?")
   end
-  
+
   # it only reaches this point once it has returned, or you
   # have manually skipped the redirect and save was called directly.
   def cleanup_authentication_session(options = {}, &block)
@@ -84,13 +74,13 @@ module AuthlogicConnect::Common::Variables
       end
     end
   end
-  
+
   def log(*methods)
     methods.each do |method|
       puts "#{method.to_s}: #{send(method).inspect}"
     end
   end
-    
+
   def log_state
     log(:correct_request_class?)
     log(:using_oauth?, :start_oauth?, :complete_oauth?)
@@ -99,7 +89,7 @@ module AuthlogicConnect::Common::Variables
     log(:authenticating_with_openid?)
     log(:stored_oauth_token_and_secret)
   end
-  
+
   # because we may need to store 6+ session variables, all with pretty lengthy names,
   # might as well just tinify them.
   # just an idea
@@ -116,9 +106,16 @@ module AuthlogicConnect::Common::Variables
     }
     @optimized_session_keys[key]
   end
-  
+
   def auto_register?
     true
   end
-  
+
+private
+
+  def convert_open_id_keys_from_hash(hash)
+    hash.each_key do |key|
+      hash[key.to_s] = hash.delete(key) if key.to_s =~ /^OpenID/
+    end
+  end
 end

--- a/test/test_user.rb
+++ b/test/test_user.rb
@@ -6,57 +6,70 @@ module AuthlogicConnect
       setup do
         @user = User.new(:login => "viatropos")
       end
-      
+
       should "make sure we are loading the models" do
         assert_equal "viatropos", @user.login
       end
-      
+
       context "responds to added oauth methods (our oauth api on the user)" do
-        
+
         should "have 'access_tokens' method" do
           assert @user.respond_to?(:access_tokens)
           assert_equal [], @user.access_tokens
         end
-        
+
         should "have 'active_token' method" do
           assert @user.respond_to?(:active_token)
           assert_equal nil, @user.active_token
         end
-        
+
       end
-      
+
       context "with controller and session..." do
-        
+
         setup do
           controller.params.merge!(:authentication_type => "user")
           Authlogic::Session::Base.controller = controller
         end
-        
+
         should "have a valid controller" do
           assert @user.auth_controller
         end
-        
+
         should "have auth_params" do
           assert @user.auth_params?
         end
-        
+
         should "have an empty 'auth_session'" do
           assert @user.auth_session.empty?
           assert_equal false, @user.auth_session?
         end
 
+        should "not change controller params hash" do
+          controller.params["foo"] = "bar"
+          assert_nil @user.auth_params[:foo]
+          assert_equal "bar", @user.auth_params["foo"]
+          assert_equal "bar", controller.params["foo"]
+        end
+
+        should "not change controller sessions hash" do
+          controller.session["foo"] = "bar"
+          assert_nil @user.auth_session[:foo]
+          assert_equal "bar", @user.auth_session["foo"]
+          assert_equal "bar", controller.session["foo"]
+        end
       end
-      
+
       context "save the user without any parameters" do
-        
+
         setup do
           @save_success = @user.save
         end
-        
+
         should "be a valid save" do
           assert @save_success
         end
-        
+
         should "not be using oauth" do
           assert_equal false, @user.using_oauth?
           # using_oauth? == (oauth_request? || oauth_response? || stored_oauth_token_and_secret?)
@@ -70,15 +83,15 @@ module AuthlogicConnect
           assert_equal false, @user.auth_session?
           assert_equal false, @user.stored_oauth_token_and_secret?
         end
-        
+
         should "not be using openid" do
           assert_equal false, @user.using_openid?
         end
-        
+
       end
-      
+
       context "user with required password field" do
-        
+
       end
     end
   end


### PR DESCRIPTION
Do not change controller params/sessions hash keys.

When symbolizing session keys, the Rails flash hash stops working, besides other possible issues that might happen. This commit updates the auth_session and auth_params hashes to not symbolize the keys, and adds tests to ensure this won't break anymore.

Thanks.
