### PR TITLE
add note about protect_from_forgery in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -114,6 +114,8 @@ Because of the redirects involved in Oauth and OpenID, you MUST pass a block to 
     end
 
 If you don't use the block, we will get a DoubleRender error.  We need the block to jump out of the rendering while redirecting.
+
+Also, be sure to skip protect_from_forgery for actions using this. Even if logs say a GET request is issued, a POST route will need to bypass forgery protection in order to yield a result to the #save block when back from auth provider.
   
 ### 7. Add Parameters to Forms in your Views
 


### PR DESCRIPTION
Hello,

I added a quick note about protect_from_forgery in the README. I found that quite tricky since logs said a GET was issued on my UserSessionsController#create action (which is quite insane since its route was limited to POST).

Maybe it will save headaches for users if you drop a line about that.
