### PR TITLE
Rails 3.1 compatibility

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -114,6 +114,8 @@ Because of the redirects involved in Oauth and OpenID, you MUST pass a block to 
     end
 
 If you don't use the block, we will get a DoubleRender error.  We need the block to jump out of the rendering while redirecting.
+
+Also, be sure to skip protect_from_forgery for actions using this. Even if logs say a GET request is issued, a POST route will need to bypass forgery protection in order to yield a result to the #save block when back from auth provider.
   
 ### 7. Add Parameters to Forms in your Views
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
-require "rake/rdoctask"
-require 'rake/gempackagetask'
+require "rdoc/task"
+require 'rubygems/package_task'
 
 # http://docs.rubygems.org/read/chapter/20
 spec = Gem::Specification.new do |s|
@@ -52,7 +52,7 @@ task :manifest do
   end
 end
 
-Rake::GemPackageTask.new(spec) do |pkg|
+Gem::PackageTask.new(spec) do |pkg|
   pkg.gem_spec    = spec
   pkg.package_dir = "pkg"
 end

--- a/lib/authlogic_connect/common/variables.rb
+++ b/lib/authlogic_connect/common/variables.rb
@@ -70,7 +70,7 @@ module AuthlogicConnect::Common::Variables
   
   # returns boolean
   def authentication_protocol(with, phase)
-    returning(send("#{phase.to_s}_#{with.to_s}?")) do |ready|
+    send("#{phase.to_s}_#{with.to_s}?").tap do |ready|
       send("#{phase.to_s}_#{with.to_s}") if ready
     end if send("using_#{with.to_s}?")
   end


### PR DESCRIPTION
Hello,

Object#returning is removed from active_support, in favor of core Object#tap : https://github.com/rails/rails/commit/b0b9bf320409b66c6c6b680371aca590297cd4cc

Also, rake/rdoctask and rake/gempackagetask are deprecated.
